### PR TITLE
Enable Android TV support

### DIFF
--- a/Oberon.Remote/ProjectSettings/ProjectSettings.asset
+++ b/Oberon.Remote/ProjectSettings/ProjectSettings.asset
@@ -281,7 +281,7 @@ PlayerSettings:
   - width: 320
     height: 180
     banner: {fileID: 0}
-  androidGamepadSupportLevel: 0
+  androidGamepadSupportLevel: 1
   AndroidMinifyRelease: 0
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1

--- a/Oberon.Remote/ProjectSettings/ProjectSettings.asset
+++ b/Oberon.Remote/ProjectSettings/ProjectSettings.asset
@@ -271,7 +271,7 @@ PlayerSettings:
   AndroidEnableArmv9SecurityFeatures: 0
   AndroidEnableArm64MTE: 0
   AndroidBuildApkPerCpuArchitecture: 0
-  AndroidTVCompatibility: 0
+  AndroidTVCompatibility: 1
   AndroidIsGame: 1
   AndroidEnableTango: 0
   androidEnableBanner: 1


### PR DESCRIPTION
Allow the remote app to be installed on Android TV without requiring a sideload. I _think_ this is the only change required but I'm not too familiar with Unity.

Connecting gamepads to the TV's bluetooth and then the Xbox to the TV IP address is pretty cool.